### PR TITLE
Use git version of document rather than local

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ version = "0.0.1"
 authors = ["Jake Goulding <jake.goulding@gmail.com>"]
 
 [dependencies.document]
-path = "../document"
+git = "https://github.com/shepmaster/sxd-document.git"


### PR DESCRIPTION
This can be overridden with a local .cargo/config file, [as explained in the guides](http://doc.crates.io/guide.html#overriding-dependencies).
