### PR TITLE
Fix character handling in string functions

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -431,7 +431,7 @@ pub struct Step {
 impl Step {
     pub fn new(axis: StepAxis, node_test: StepTest, predicates: Vec<SubExpression>) -> Step {
         let mut predicates = predicates;
-        let preds = predicates.drain().map(|p| Predicate { expression: p }).collect();
+        let preds = predicates.drain(..).map(|p| Predicate { expression: p }).collect();
         Step { axis: axis, node_test: node_test, predicates: preds }
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -384,7 +384,7 @@ impl Function for Substring {
         let start = round_ties_to_positive_infinity(start);
         let s = try!(args.pop_string());
 
-        let chars = s.graphemes(true).enumerate();
+        let chars = s.chars().enumerate();
         let selected_chars = chars.filter_map(|(p, s)| {
             let p = (p+1) as f64; // 1-based indexing
             if p >= start && p < start + len {
@@ -408,7 +408,7 @@ impl Function for StringLength {
         let mut args = Args(args);
         try!(args.at_most(1));
         let arg = try!(args.pop_string_value_or_context_node(context));
-        Ok(Value::Number(arg.graphemes(true).count() as f64))
+        Ok(Value::Number(arg.chars().count() as f64))
     }
 }
 
@@ -444,15 +444,15 @@ impl Function for Translate {
         let s = try!(args.pop_string());
 
         let mut replacements = HashMap::new();
-        let pairs = from.graphemes(true).zip(to.graphemes(true).chain(iter::repeat("")));
+        let pairs = from.chars().zip(to.chars().map(|c| Some(c)).chain(iter::repeat(None)));
         for (from, to) in pairs {
             if let Entry::Vacant(entry) = replacements.entry(from) {
                 entry.insert(to);
             }
         }
 
-        let s = s.graphemes(true).map(|c| {
-            replacements.get(c).map(|&s| s).unwrap_or(c)
+        let s = s.chars().filter_map(|c| {
+            replacements.get(&c).map(|&s| s).unwrap_or(Some(c))
         }).collect();
 
         Ok(Value::String(s))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(core)]
-#![feature(unicode)]
+#![feature(collections_drain)]
 #![cfg_attr(test, feature(slice_patterns))]
 
 #[macro_use]


### PR DESCRIPTION
- http://www.w3.org/TR/xpath/#strings says that characters in XPath are "Unicode Scalar Values" which is the same as `char` in Rust, so don't use graphemes (also they are deprecated in std).
- Update for recent change in `drain`