### PR TITLE
Add a function for simple absolute XPath evaluation.

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -15,6 +15,7 @@ pub enum Error {
     NotANodeset,
     UnknownFunction(String),
     UnknownVariable(String),
+    InvalidXPath(String),
     FunctionEvaluation(function::Error),
 }
 
@@ -25,6 +26,7 @@ impl error::Error for Error {
             &NotANodeset               => "expression did not evaluate to a nodeset",
             &UnknownFunction(..)       => "unknown function",
             &UnknownVariable(..)       => "unknown variable",
+            &InvalidXPath(..)          => "invalid XPath",
             &FunctionEvaluation(ref f) => f.description(),
         }
     }
@@ -43,6 +45,9 @@ impl fmt::Display for Error {
             },
             &UnknownVariable(ref v) => {
                 write!(fmt, "unknown variable {}", v)
+            },
+            &InvalidXPath(ref x) => {
+                write!(fmt, "invalid XPath {}", x)
             },
             &FunctionEvaluation(ref f) => {
                 try!(write!(fmt, "error while evaluating function: "));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ impl Factory {
 /// # Examples
 ///
 /// ```no_run
-/// # fn foo {
+/// # fn foo() {
 /// extern crate sxd_document;
 /// extern crate sxd_xpath;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ impl Factory {
 }
 
 /// Evaluate an absolute XPath expression
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// extern crate sxd_document;
@@ -257,7 +257,7 @@ impl Factory {
 /// use sxd_xpath::evaluate_absolute_xpath;
 ///
 /// let mut buffer = String::new();
-/// let mut file = File::open("C:\\path\\to\\some\\file.xml").expect(failed to read the file);
+/// let mut file = File::open("C:\\path\\to\\some\\file.xml").expect("failed to read the file");
 /// let _ = file.read_to_string(&mut buffer);
 /// let package = parser::parse(&buffer).expect("failed to parse the XML");
 /// let document = package.as_document();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::{iter,string};
 
+use sxd_document::dom::Document;
+
 use self::Value::{Boolean,Number,String};
 
 use nodeset::{Nodeset,Node};
@@ -242,13 +244,53 @@ impl Factory {
     }
 }
 
+/// Evaluate an absolute XPath expression
+/// # Example
+///
+/// ```no_run
+/// extern crate sxd_document;
+/// extern crate sxd_xpath;
+///
+/// use std::fs::File;
+/// use std::io::Read;
+/// use sxd_document::parser;
+/// use sxd_xpath::evaluate_absolute_xpath;
+///
+/// let mut buffer = String::new();
+/// let mut file = File::open("C:\\path\\to\\some\\file.xml").expect(failed to read the file);
+/// let _ = file.read_to_string(&mut buffer);
+/// let package = parser::parse(&buffer).expect("failed to parse the XML");
+/// let document = package.as_document();
+///
+/// let result = evaluate_absolute_xpath(&document, "/some/absolute/XPath");
+/// ```
+pub fn evaluate_absolute_xpath<'d>(document: &'d Document<'d>, xpath: &str) -> Option<Result<Value<'d>, ExpressionError>> {
+    let mut functions = HashMap::new();
+    let variables = HashMap::new();
+    let namespaces = HashMap::new();
+    let factory = Factory::new();
+    function::register_core_functions(&mut functions);
+    let context = EvaluationContext::new(
+        document.root(),
+        &functions,
+        &variables,
+        &namespaces,
+    );
+    let expression = factory.build(xpath);
+    match expression {
+        Err(e) => Some(Err(ExpressionError::InvalidXPath(format!("{}", e)))),
+        Ok(None) => None,
+        Ok(Some(r)) => Some(r.evaluate(&context))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::borrow::ToOwned;
 
-    use sxd_document::Package;
+    use sxd_document::{Package, parser};
 
-    use super::Value;
+    use super::{Value, ExpressionError, evaluate_absolute_xpath};
 
     #[test]
     fn number_of_string_is_ieee_754_number() {
@@ -366,5 +408,21 @@ mod test {
 
         let v = Value::Nodeset(nodeset![c2, c1]);
         assert_eq!("comment 1", v.string());
+    }
+
+    #[test]
+    fn absolute_xpath_evaluation() {
+        let package = parser::parse("<?xml version='1.0'?><root><child>content</child></root>").unwrap();
+        let doc = package.as_document();
+
+        let result1 = evaluate_absolute_xpath(&doc, "/root/child");
+        let result2 = evaluate_absolute_xpath(&doc, "/root/child/");
+        let result3 = evaluate_absolute_xpath(&doc, "2 + 2");
+        let result4 = evaluate_absolute_xpath(&doc, "");
+
+        assert_eq!("content", result1.unwrap().unwrap().string());
+        assert_eq!(Some(Err(ExpressionError::InvalidXPath("trailing slash".to_owned()))), result2);
+        assert_eq!(Some(Ok(Value::Number(4.0))), result3);
+        assert_eq!(None, result4);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,7 @@ impl Factory {
 /// # Examples
 ///
 /// ```no_run
+/// # fn foo {
 /// extern crate sxd_document;
 /// extern crate sxd_xpath;
 ///
@@ -263,6 +264,7 @@ impl Factory {
 /// let document = package.as_document();
 ///
 /// let result = evaluate_absolute_xpath(&document, "/some/absolute/XPath");
+/// # }
 /// ```
 pub fn evaluate_absolute_xpath<'d>(document: &'d Document<'d>, xpath: &str) -> Option<Result<Value<'d>, ExpressionError>> {
     let mut functions = HashMap::new();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@ use std::borrow::ToOwned;
 use std::collections::HashMap;
 use sxd_document::dom::Document;
 use sxd_document::parser::parse;
-use sxd_xpath::{Value,Functions,Variables,Namespaces,Factory,EvaluationContext,Expression};
+use sxd_xpath::{Value,Functions,Variables,Namespaces,Factory,EvaluationContext};
 
 #[test]
 fn functions_accept_arguments() {


### PR DESCRIPTION
The existing `evaluate` function requires lots of research, configuration and additional imports to use, while the poor souls that have to process XMLs usually just need to be able to execute simple XPath expressions. The `evaluate_absolute_xpath` function only needs a `Document` and an XPath `&str` to work and it returns a `Value` in wrappers ready to accomodate various possible errors.

In addition, this extends the `expression::Error`struct with an `InvalidXPath` variant so that potential XPath-related `parser::ParseErr` errors can be handled. It is not perfect; instead of a `String` I would prefer to relay `ParseErr`, but it would break the `ExpressionError`'s `Hash` property - deriving `Hash` would fail due to `Token` having an `f64` variant.

The last modification in the `integration.rs` file is just a deletion of an unused trait import (`Expression`).