### PR TITLE
Make Factory::build return Result<XPath>

### DIFF
--- a/evaluate/src/main.rs
+++ b/evaluate/src/main.rs
@@ -19,11 +19,9 @@ fn print_usage(program: &str, opts: &Options) {
 fn build_xpath(xpath_str: &str) -> XPath {
     let factory = Factory::new();
 
-    match factory.build(xpath_str) {
-        Err(x) => panic!("Unable to compile XPath {}: {}", xpath_str, x),
-        Ok(None) => panic!("Unable to compile XPath"),
-        Ok(Some(x)) => x,
-    }
+    factory
+        .build(xpath_str)
+        .unwrap_or_else(|e| panic!("Unable to compile XPath {}: {}", xpath_str, e))
 }
 
 fn load_xml<R>(input: R) -> sxd_document::Package

--- a/src/context.rs
+++ b/src/context.rs
@@ -62,7 +62,6 @@ type Namespaces = HashMap<String, String>;
 ///
 ///     let factory = Factory::new();
 ///     let xpath = factory.build(xpath).expect("Could not compile XPath");
-///     let xpath = xpath.expect("No XPath was compiled");
 ///
 ///     let value = xpath.evaluate(&context, node).expect("XPath evaluation failed");
 ///

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -104,11 +104,7 @@ impl<'d> Setup<'d> {
     }
 
     fn evaluate(&self, doc: &'d dom::Document<'d>, xpath: &str) -> Value<'d> {
-        let xpath = self
-            .factory
-            .build(xpath)
-            .expect("Unable to build XPath")
-            .expect("No XPath was built");
+        let xpath = self.factory.build(xpath).expect("Unable to build XPath");
         xpath
             .evaluate(&self.context, doc.root())
             .expect("Unable to evaluate XPath")


### PR DESCRIPTION
This is an attempt at resolving #111, by treating the error variant `Error::NoXPath` as a parsing `parser::Error`.
Hence, the `Ok(None)` case would now become an `Err(ParserError(NoXPath))` immediately on `Factory::build`.