### PR TITLE
Fix the behavior of negative zero

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,9 @@ impl<'d> Value<'d> {
                     } else {
                         "Infinity".to_owned()
                     }
+                } else if n == 0.0 {
+                    // Covers both negative and positive zero
+                    "0".to_owned()
                 } else {
                     n.to_string()
                 }


### PR DESCRIPTION
Hi, I tried to compile and pass all the tests, but one failing test caught my eye:

```
---- test::string_of_negative_zero_is_zero stdout ----
thread 'test::string_of_negative_zero_is_zero' panicked at 'assertion failed: `(left == right)`
  left: `"0"`,
 right: `"-0"`', src/lib.rs:545:9
```

It reminds me of the [signed zero](https://en.wikipedia.org/wiki/Signed_zero) in IEEE 754, which indicates the sign of a zero, regardless of the fact that `0.0 == -0.0`. Therefore, a direct `to_string()` will make the test fail if the test case constructs `-0.0` deliberately.

This patch passes the test by additionally judging whether the number to be returned equals zero. Since `0.0 == -0.0`, both should be treated as `0.0` when printing.

It's is a tiny patch and only takes perhaps less than a minute to check and comment. The library is great, I find it handy. Thanks, and have a nice day / night : )